### PR TITLE
FEATURE: two new settings for email_valid defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 auto_generated
 gems
-
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Add the following settings to your `app.yml` file in the Environment Settings se
   DISCOURSE_SAML_CERT_FINGERPRINT: "43:BB:DA:FF..."
   #DISCOURSE_SAML_REQUEST_METHOD: post
   #DISCOURSE_SAML_FULL_SCREEN_LOGIN: true
-  DISCOURSE_SAML_CERT: "-----BEGIN CERTIFICATE----- 
+  DISCOURSE_SAML_CERT: "-----BEGIN CERTIFICATE-----
   ...
   -----END CERTIFICATE-----"
 ```
@@ -34,6 +34,16 @@ For non docker:
 Add the following settings to your `discourse.conf` file:
 
 - `saml_target_url`
+
+### Supported settings
+
+- `DISCOURSE_SAML_SP_CERTIFICATE`: SAML Service Provider Certificate
+- `DISCOURSE_SAML_SP_PRIVATE_KEY`: SAML Service Provider Private Key
+- `DISCOURSE_SAML_AUTHN_REQUESTS_SIGNED`: defaults to false
+- `DISCOURSE_SAML_WANT_ASSERTIONS_SIGNED`: defaults to false
+- `DISCOURSE_SAML_NAME_IDENTIFIER_FORMAT`: defaults to "urn:oasis:names:tc:SAML:2.0:protocol"
+- `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`: defaults to true
+- `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`: defaults to blank. This setting accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.
 
 ### Convering an RSA Key to a PEM
 

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -34,6 +34,44 @@ describe SamlAuthenticator do
 
       result = @authenticator.after_authenticate(hash)
       expect(result.user.email).to eq(@user.email)
+      expect(result.email_valid).to eq(true)
+    end
+
+    it 'defaults email_valid to false if saml_default_emails_valid is false' do
+      GlobalSetting.stubs(:saml_default_emails_valid).returns(false)
+
+      hash = OmniAuth::AuthHash.new(
+        uid: @uid,
+        info: {
+            name: "John Doe",
+            email: @user.email
+        }
+      )
+
+      result = @authenticator.after_authenticate(hash)
+      expect(result.user.email).to eq(@user.email)
+      expect(result.email_valid).to eq(false)
+    end
+
+    it 'defaults email_valid based on saml_validate_email_fields setting' do
+      GlobalSetting.stubs(:saml_validate_email_fields).returns("customers")
+
+      hash = OmniAuth::AuthHash.new(
+        uid: @uid,
+        info: {
+            name: "John Doe",
+            email: @user.email
+        },
+        extra: {
+          raw_info: OneLogin::RubySaml::Attributes.new({
+            'memberOf' => %w(Customers Employees)
+          })
+        }
+      )
+
+      result = @authenticator.after_authenticate(hash)
+      expect(result.user.email).to eq(@user.email)
+      expect(result.email_valid).to eq(true)
     end
   end
 end


### PR DESCRIPTION
This PR adds two new settings:

- `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`
- `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`

By default `email_valid` is true, this behaviour can be changed by setting `DISCOURSE_SAML_DEFAULT_EMAILS_VALID` to "false".

`DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS` accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.