### PR TITLE
don't redirect to login, that is what we're trying to do

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -32,6 +32,8 @@ if request_method == 'post'
 
     class DiscourseSaml::DiscourseSamlController < ::ApplicationController
       skip_before_action :check_xhr
+      skip_before_action :redirect_to_login_if_required, only: [:index]
+
       def index
         authn_request = OneLogin::RubySaml::Authrequest.new
 


### PR DESCRIPTION
If a site has login_required set, then the /discourse_saml route redirects to /login, which is not helpful