### PR TITLE
Allow changing of the groups attribute name

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -185,7 +185,8 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     return unless GlobalSetting.try(:saml_sync_groups)
 
     total_group_list = (GlobalSetting.try(:saml_sync_groups_list) || "").split('|')
-    user_group_list = attributes['memberOf'] || []
+    group_attribute = GlobalSetting.try(:saml_groups_attribute) || 'memberOf'
+    user_group_list = attributes[group_attribute] || []
     groups_to_add = user_group_list + attr('groups_to_add').split(",")
     groups_to_remove = attr('groups_to_remove').split(",")
 


### PR DESCRIPTION
The name of the attribute that contains the user's groups should be changeable.
Ipsilon IdP for example uses just 'groups', and that is hardcoded.

Please advise if parameter name is sensible/conforming to your standards.