### PR TITLE
FIX: leading backslash so UrlHelper will apply CDN

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -172,7 +172,7 @@ if request_method == 'post'
         saml_params = authn_request.create_params(settings, {})
         @saml_req = saml_params['SAMLRequest']
 
-        script_path = 'plugins/discourse-saml/javascripts/submit-form-on-load.js'
+        script_path = '/plugins/discourse-saml/javascripts/submit-form-on-load.js'
 
         render inline: <<-HTML_FORM
   <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">


### PR DESCRIPTION
It works without the backslash, but it is loaded without the CDN. 