### PR TITLE
[+] Extra auth fields settings & FR localized & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@
 A Discourse Plugin to enable authentication via SAML
 
 Setting up your idp:
-The entity-id should be: `http://example.com`
-The consumer assertion service url should be: `https://example.com/auth/saml/callback`
+The entity-id should be: `http://example.com` or can be defined with `DISCOURSE_SAML_ISSUER`.
+The consumer assertion service url should be: `https://example.com/auth/saml/callback` or can be defined with `DISCOURSE_SAML_ASSERTION_URL`.
 
 You may need to set your idp to send an extra custom attribute 'screenName', that will become the users id.
 
@@ -42,13 +42,26 @@ Add the following settings to your `discourse.conf` file:
 
 - `DISCOURSE_SAML_SP_CERTIFICATE`: SAML Service Provider Certificate
 - `DISCOURSE_SAML_SP_PRIVATE_KEY`: SAML Service Provider Private Key
+- `DISCOURSE_SAML_ASSERTION_URL`: Callback URL  defaults to "base_url + /auth/saml/callback"
+- `DISCOURSE_SAML_ISSUER`: SAML Service Provider entity-id (issuer)
 - `DISCOURSE_SAML_AUTHN_REQUESTS_SIGNED`: defaults to false
 - `DISCOURSE_SAML_WANT_ASSERTIONS_SIGNED`: defaults to false
 - `DISCOURSE_SAML_NAME_IDENTIFIER_FORMAT`: defaults to "urn:oasis:names:tc:SAML:2.0:protocol"
 - `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`: defaults to true
 - `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`: defaults to blank. This setting accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.
 
-### Convering an RSA Key to a PEM
+If SAML provider return user informations  in "extrafields", use these settings:
+
+- `DISCOURSE_SAML_EXTRAFIELD_EMAIL`: optional, defaults to blank: define user email  
+- `DISCOURSE_SAML_EXTRAFIELD_FIRSTNAME`: optional, define user firstname
+- `DISCOURSE_SAML_EXTRAFIELD_LASTNAME`: optional, define user lastname
+
+"FIRSTNAME" & "LASTNAME" will be use for fullname, if only one of them are set, fullname will be firstname || lastname
+
+- `DISCOURSE_SAML_EXTRAFIELD_COMPANY`: optional, add user company in fullname : fullname + (company)  
+
+
+### Converting an RSA Key to a PEM
 
 If the idp has an RSA key split up as modulus and exponent, this javascript library makes
 it easy to convert to pem:

--- a/config/locales/server.fr.yml
+++ b/config/locales/server.fr.yml
@@ -1,0 +1,3 @@
+fr:
+  login:
+    use_saml_auth: "Merci d'utiliser la Fédération d'Identités de l'entreprise pour vous authentifier."

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -113,6 +113,33 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
       username ||= uid
       username
     end
+    
+    if attributes.present?
+        
+        email_extrafield = GlobalSetting.try(:saml_extrafield_email).presence || ""
+        firstname_extrafield = GlobalSetting.try(:saml_extrafield_firstname).presence || ""
+        lastname_extrafield = GlobalSetting.try(:saml_extrafield_lastname).presence || ""
+        company_extrafield = GlobalSetting.try(:saml_extrafield_company).presence || ""
+        
+        unless email_extrafield.nil? || email_extrafield.empty?
+            result.email = attributes[email_extrafield].try(:first)
+        end
+
+        unless firstname_extrafield.nil? || firstname_extrafield.empty?
+            result.name = attributes[firstname_extrafield].try(:first) || ""
+        end
+        
+        if (lastname_extrafield != nil && !firstname_extrafield.empty?)
+            result.name = result.name + " " + attributes[lastname_extrafield].try(:first)
+        elsif (lastname_extrafield != nil)
+            result.name = attributes[lastname_extrafield].try(:first) || ""
+        end
+        
+        unless company_extrafield.nil? && result.name.empty?
+            result.name = result.name + " (" + attributes[company_extrafield].try(:first) + ")"
+        end
+            
+    end
 
     if result.respond_to?(:skip_email_validation) && GlobalSetting.try(:saml_skip_email_validation)
       result.skip_email_validation = true

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -121,21 +121,21 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
         lastname_extrafield = GlobalSetting.try(:saml_extrafield_lastname).presence || ""
         company_extrafield = GlobalSetting.try(:saml_extrafield_company).presence || ""
         
-        unless email_extrafield.nil? || email_extrafield.empty?
+        unless email_extrafield.blank?
             result.email = attributes[email_extrafield].try(:first)
         end
 
-        unless firstname_extrafield.nil? || firstname_extrafield.empty?
+        unless firstname_extrafield.blank?
             result.name = attributes[firstname_extrafield].try(:first) || ""
         end
         
-        if (lastname_extrafield != nil && !firstname_extrafield.empty?)
+        if !lastname_extrafield.blank? && !result.name.blank?
             result.name = result.name + " " + attributes[lastname_extrafield].try(:first)
-        elsif (lastname_extrafield != nil)
+        elsif !lastname_extrafield.blank?
             result.name = attributes[lastname_extrafield].try(:first) || ""
         end
         
-        unless company_extrafield.nil? && result.name.empty?
+        unless company_extrafield.blank? || result.name.blank?
             result.name = result.name + " (" + attributes[company_extrafield].try(:first) + ")"
         end
             

--- a/plugin.rb
+++ b/plugin.rb
@@ -165,8 +165,8 @@ if request_method == 'post'
 
         settings.compress_request = false
         settings.passive = false
-        settings.issuer = Discourse.base_url
-        settings.assertion_consumer_service_url = Discourse.base_url + "/auth/saml/callback"
+        settings.issuer = GlobalSetting.try(:saml_issuer) || Discourse.base_url
+        settings.assertion_consumer_service_url = GlobalSetting.try(:saml_assertion_url) || Discourse.base_url + "/auth/saml/callback"
         settings.name_identifier_format = GlobalSetting.try(:saml_name_identifier_format) || "urn:oasis:names:tc:SAML:2.0:protocol"
 
         saml_params = authn_request.create_params(settings, {})


### PR DESCRIPTION
Hello,

First of all, happy new year !

Thank you to provide plugins like this one and let us have a look on sources.

I'm working for SNCF, the french national railway company and i'm deploying a Discourse to centralize every question/answer on our different tools.

To get that working with the company authentication, i'd to add some settings to retrieve users infos in extra fields callback.

I'm sure these settings can be usefull for other company using non-conventional fields to get user infos.

Hope it can help,

Best regards,

Mehdi Abby