### PR TITLE
background_color has been deprecated

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -218,6 +218,5 @@ auth_provider title: button_title,
               message: "Authorizing with #{title} (make sure pop up blockers are not enabled)",
               frame_width: GlobalSetting.try(:saml_frame_width) || 600,
               frame_height: GlobalSetting.try(:saml_frame_height) || 400,
-              background_color: '#003366',
               full_screen_login: GlobalSetting.try(:saml_full_screen_login) || false,
               custom_url: request_method == 'post' ? "/discourse_saml" : nil


### PR DESCRIPTION
See https://meta.discourse.org/t/auth-provider-plugin-information-for-plugin-authors/102392

Prevents this message from being logged

```
Deprecation notice: background_color is no longer functional. Please use CSS instead 
At /var/www/discourse/lib/plugin/instance.rb:527:in `block (2 levels) in auth_provider`
```