### PR TITLE
Support for overriding base_url using saml_base_url GlobalSetting (take 2)

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -49,17 +49,17 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
   def register_middleware(omniauth)
     omniauth.provider :saml,
                       name: name,
-                      issuer: saml_base_url,
+                      issuer: SamlAuthenticator.saml_base_url,
                       idp_sso_target_url: setting(:target_url),
                       idp_slo_target_url: setting(:slo_target_url),
-                      slo_default_relay_state: saml_base_url,
+                      slo_default_relay_state: SamlAuthenticator.saml_base_url,
                       idp_cert_fingerprint: GlobalSetting.try(:saml_cert_fingerprint),
                       idp_cert_fingerprint_algorithm: GlobalSetting.try(:saml_cert_fingerprint_algorithm),
                       idp_cert: setting(:cert),
                       request_attributes: request_attributes,
                       attribute_statements: attribute_statements,
-                      assertion_consumer_service_url: saml_base_url + "/auth/#{name}/callback",
-                      single_logout_service_url: saml_base_url + "/auth/#{name}/slo",
+                      assertion_consumer_service_url: SamlAuthenticator.saml_base_url + "/auth/#{name}/callback",
+                      single_logout_service_url: SamlAuthenticator.saml_base_url + "/auth/#{name}/slo",
                       name_identifier_format: GlobalSetting.try(:saml_name_identifier_format),
                       custom_url: (GlobalSetting.try(:saml_request_method) == 'post') ? "/discourse_saml" : nil,
                       certificate: GlobalSetting.try(:saml_sp_certificate),
@@ -299,7 +299,7 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     true # SAML plugin has no enabled setting
   end
 
-  def saml_base_url 
+  def self.saml_base_url 
     GlobalSetting.try(:saml_base_url) || Discourse.base_url
   end
 

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -49,17 +49,17 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
   def register_middleware(omniauth)
     omniauth.provider :saml,
                       name: name,
-                      issuer: Discourse.base_url,
+                      issuer: saml_base_url,
                       idp_sso_target_url: setting(:target_url),
                       idp_slo_target_url: setting(:slo_target_url),
-                      slo_default_relay_state: Discourse.base_url,
+                      slo_default_relay_state: saml_base_url,
                       idp_cert_fingerprint: GlobalSetting.try(:saml_cert_fingerprint),
                       idp_cert_fingerprint_algorithm: GlobalSetting.try(:saml_cert_fingerprint_algorithm),
                       idp_cert: setting(:cert),
                       request_attributes: request_attributes,
                       attribute_statements: attribute_statements,
-                      assertion_consumer_service_url: Discourse.base_url + "/auth/#{name}/callback",
-                      single_logout_service_url: Discourse.base_url + "/auth/#{name}/slo",
+                      assertion_consumer_service_url: saml_base_url + "/auth/#{name}/callback",
+                      single_logout_service_url: saml_base_url + "/auth/#{name}/slo",
                       name_identifier_format: GlobalSetting.try(:saml_name_identifier_format),
                       custom_url: (GlobalSetting.try(:saml_request_method) == 'post') ? "/discourse_saml" : nil,
                       certificate: GlobalSetting.try(:saml_sp_certificate),
@@ -298,4 +298,9 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
   def enabled?
     true # SAML plugin has no enabled setting
   end
+
+  def saml_base_url 
+    GlobalSetting.try(:saml_base_url) || Discourse.base_url
+  end
+
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,7 +23,7 @@ after_initialize do
   if GlobalSetting.try(:saml_slo_target_url).present?
     SiteSetting.class_eval do
       def self.logout_redirect
-        Discourse.base_url + "/auth/saml/spslo"
+        SamlAuthenticator.saml_base_url + "/auth/saml/spslo"
       end
     end
   end
@@ -165,8 +165,8 @@ if request_method == 'post'
 
         settings.compress_request = false
         settings.passive = false
-        settings.issuer = Discourse.base_url
-        settings.assertion_consumer_service_url = Discourse.base_url + "/auth/saml/callback"
+        settings.issuer = SamlAuthenticator.saml_base_url
+        settings.assertion_consumer_service_url = SamlAuthenticator.saml_base_url + "/auth/saml/callback"
         settings.name_identifier_format = GlobalSetting.try(:saml_name_identifier_format) || "urn:oasis:names:tc:SAML:2.0:protocol"
 
         saml_params = authn_request.create_params(settings, {})


### PR DESCRIPTION
I was finally able to make the changes as suggested [here](https://github.com/discourse/discourse-saml/pull/19). 

This change allows overriding the base URL with a GlobalSetting called saml_base_url.
