### PR TITLE
Use render html: instead of render inline:

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -174,7 +174,7 @@ if request_method == 'post'
 
         script_path = '/plugins/discourse-saml/javascripts/submit-form-on-load.js'
 
-        render inline: <<-HTML_FORM
+        render html: <<-HTML_FORM
   <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
     <body>
       <noscript>


### PR DESCRIPTION
The current code will render the contents as ERB, which means that if it's possible for someone to inject content into `@saml_req`, they can execute arbitrary code.

I don't use DIscourse, so this change is currently *untested*.