### PR TITLE
Fix adding user to his first group

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -212,8 +212,8 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
 
     if groups_fullsync
       user_has_groups = user.groups.where(automatic: false).pluck(:name).map(&:downcase)
+      groups_to_add = user_group_list - user_has_groups
       if user_has_groups.present?
-        groups_to_add = user_group_list - user_has_groups
         groups_to_remove = user_has_groups - user_group_list
       end
     else

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -250,6 +250,11 @@ describe SamlAuthenticator do
         )
       end
 
+      it 'full sync with a user who has no group membership currently' do
+        result = @authenticator.after_authenticate(@hash)
+        expect(result.user.groups.pluck(:name)).to match_array(group_names[0..1].map(&:downcase))
+      end
+
       it 'sync users to the given groups' do
         @groups[0].add @user
         @groups[3].add @user


### PR DESCRIPTION
In case the user isn't assigned to any (non-automatic) group, the user
wasn't added.