### PR TITLE
FEATURE: Add settings for signing logout requests and responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Add the following settings to your `discourse.conf` file:
 - `DISCOURSE_SAML_SP_PRIVATE_KEY`: SAML Service Provider Private Key
 - `DISCOURSE_SAML_AUTHN_REQUESTS_SIGNED`: defaults to false
 - `DISCOURSE_SAML_WANT_ASSERTIONS_SIGNED`: defaults to false
+- `DISCOURSE_SAML_LOGOUT_REQUESTS_SIGNED`: defaults to false
+- `DISCOURSE_SAML_LOGOUT_RESPONSES_SIGNED`: defaults to false
 - `DISCOURSE_SAML_NAME_IDENTIFIER_FORMAT`: defaults to "urn:oasis:names:tc:SAML:2.0:protocol"
 - `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`: defaults to true
 - `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`: defaults to blank. This setting accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -69,6 +69,8 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
                       security: {
                         authn_requests_signed: !!GlobalSetting.try(:saml_authn_requests_signed),
                         want_assertions_signed: !!GlobalSetting.try(:saml_want_assertions_signed),
+                        logout_requests_signed: !!GlobalSetting.try(:saml_logout_requests_signed),                                                                                                                 
+                        logout_responses_signed: !!GlobalSetting.try(:saml_logout_responses_signed),
                         signature_method: XMLSecurity::Document::RSA_SHA1
                       },
                       idp_slo_session_destroy: proc { |env, session| @user.user_auth_tokens.destroy_all; @user.logged_out }


### PR DESCRIPTION
I've added two settings that Ruby SAML processes when creating or answering a logout request:
- `logout_requests_signed`: [defaults to false](https://github.com/onelogin/ruby-saml/blob/63f43a7f9b830dfd690457a78a78fac48359944f/lib/onelogin/ruby-saml/settings.rb#L233)
- `logout_responses_signed`: [defaults to false](https://github.com/onelogin/ruby-saml/blob/63f43a7f9b830dfd690457a78a78fac48359944f/lib/onelogin/ruby-saml/settings.rb#L234)

https://github.com/onelogin/ruby-saml#signing

We need them for integration with our idp that expects service providers to sign all requests and responses.