### PR TITLE
FEATURE: sync user fields as per `saml_user_field_statements` env variable.

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -251,7 +251,20 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
       key = attr[:name]
       user.custom_fields["#{name}_#{key}"] = attr(key) if attr(key).present?
     end
+
+    sync_user_fields
     user.save_custom_fields
+  end
+
+  def sync_user_fields
+    statements = GlobalSetting.try(:saml_user_field_statements) || ""
+
+    statements.split("|").each do |statement|
+      key, field_id = statement.split(":")
+      next if key.blank? || field_id.blank?
+
+      user.custom_fields["user_field_#{field_id}"] = attr(key) if attr(key).present?
+    end
   end
 
   def sync_email(email, uid)

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -111,6 +111,23 @@ describe SamlAuthenticator do
       end
     end
 
+    it 'syncs user fields based on `saml_user_field_statements` environment variable' do
+      GlobalSetting.stubs(:saml_user_field_statements).returns("department:2|title:3")
+
+      hash = auth_hash(
+        'department' => ["HR", "Manager"],
+        'title' => ["Senior HR Manager"]
+      )
+
+      result = @authenticator.after_authenticate(hash)
+      attrs = hash.extra.raw_info.attributes
+
+      GlobalSetting.saml_user_field_statements.split("|").each do |statement|
+        key, id = statement.split(":")
+        expect(result.user.custom_fields["user_field_#{id}"]).to eq(attrs[key].join(","))
+      end
+    end
+
     it 'should get uid value from extra attributes param' do
       GlobalSetting.stubs(:saml_use_attributes_uid).returns("true")
 


### PR DESCRIPTION
Now we can sync or create user fields based on the new `saml_user_field_statements` environment variable's mapping.