### PR TITLE
DEV: explicitly require `rexml` gem in the plugin file.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -12,6 +12,7 @@ require_dependency 'auth/oauth2_authenticator'
 
 gem 'macaddr', '1.0.0'
 gem 'uuid', '2.3.7'
+gem 'rexml', '2.3.5'
 gem 'ruby-saml', '1.13.0'
 gem "omniauth-saml", '1.9.0'
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -12,7 +12,7 @@ require_dependency 'auth/oauth2_authenticator'
 
 gem 'macaddr', '1.0.0'
 gem 'uuid', '2.3.7'
-gem 'rexml', '2.3.5'
+gem 'rexml', '3.2.5'
 gem 'ruby-saml', '1.13.0'
 gem "omniauth-saml", '1.9.0'
 


### PR DESCRIPTION
Our hosted sites running in stable branch have issues with `rexml` gem and returning "missing gem" error. This gem is required by 'ruby-saml v1.13.0' gem.