### PR TITLE
FEATURE: Add support for automatic approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Add the following settings to your `discourse.conf` file:
 - `DISCOURSE_SAML_NAME_IDENTIFIER_FORMAT`: defaults to "urn:oasis:names:tc:SAML:2.0:protocol"
 - `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`: defaults to true
 - `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`: defaults to blank. This setting accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.
+- `DISCOURSE_SAML_AUTOAPPROVE`: defaults to false. If set to `true` the user is approved automatically even if Discourse is configured to require approval of new users.
 - `DISCOURSE_SAML_BUTTON_TITLE`: 'with SAML'
 - `DISCOURSE_SAML_TITLE`: 'SAML'
 - `DISCOURSE_SAML_SYNC_MODERATOR`: defaults to false. If set to `true` user get moderator role if SAML attribute `isModerator` (or attribute specified by `DISCOURSE_SAML_MODERATOR_ATTRIBUTE`) is 1 or true.  

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -203,6 +203,9 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
         username: UserNameSuggester.suggest(try_username || try_name || email),
         active: true
       }
+      if GlobalSetting.try(:saml_autoapprove)
+        user_params["approved"] = true
+      end
 
       user = User.create!(user_params)
       after_create_account(user, result.as_json.with_indifferent_access)

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -370,6 +370,43 @@ describe SamlAuthenticator do
       end
     end
 
+    describe "autoapprove" do
+      before do
+        GlobalSetting.stubs(:saml_auto_create_account).returns(true)
+        SiteSetting.stubs(:must_approve_users).returns(true)
+      end
+
+      it 'user should be approved automatically' do
+        GlobalSetting.stubs(:saml_autoapprove).returns(true)
+        name = "Jane Doe"
+        email = "janedoe@example.com"
+        hash = OmniAuth::AuthHash.new(
+          uid: @uid,
+          info: {
+              name: name,
+              email: email
+          }
+        )
+        result = @authenticator.after_authenticate(hash)
+        expect(result.user.approved).to eq(true)
+      end
+
+      it 'user should not be approved automatically' do
+        GlobalSetting.stubs(:saml_autoapprove).returns(false)
+        name = "Johnny Doe"
+        email = "johnnydoe@example.com"
+        hash = OmniAuth::AuthHash.new(
+          uid: @uid,
+          info: {
+              name: name,
+              email: email
+          }
+        )
+        result = @authenticator.after_authenticate(hash)
+        expect(result.user.approved).to eq(false)
+      end
+    end
+
     describe "set trust_level" do
       before do
         GlobalSetting.stubs(:saml_sync_trust_level).returns(true)


### PR DESCRIPTION
This adds a setting to automatically approve new users created via SAML even if the forum setting `must approve users` is activated.