### PR TITLE
FIX: Update name selection logic

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -33,7 +33,7 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
 
   def attribute_statements
     result = {}
-    statements = "name:name|email:email,mail|first_name:first_name,firstname,firstName|last_name:last_name,lastname,lastName|nickname:screenName"
+    statements = "name:fullName,name|email:email,mail|first_name:first_name,firstname,firstName|last_name:last_name,lastname,lastName|nickname:screenName"
     custom_statements = GlobalSetting.try(:saml_attribute_statements)
 
     statements = "#{statements}|#{custom_statements}" if custom_statements.present?
@@ -129,11 +129,8 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     end
 
     result.name = begin
-      if attributes.present?
-        fullname = attributes['fullName'].try(:first)
-        fullname = "#{attributes['firstName'].try(:first)} #{attributes['lastName'].try(:first)}"
-      end
-      fullname ||= result.name
+      fullname = auth.info[:name].presence # From fullName, name, or other custom attribute_statement
+      fullname ||= "#{auth.info[:first_name]} #{auth.info[:last_name]}"
       fullname
     end
 

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -221,6 +221,42 @@ describe SamlAuthenticator do
       end
     end
 
+    describe "name" do
+      let(:name) { "John Doe" }
+      let(:first_name) { "Jane" }
+      let(:last_name) { "Smith" }
+      let(:email) { "johndoe@example.com" }
+      let(:screen_name) { "johndoe" }
+      let(:hash) { OmniAuth::AuthHash.new(
+          uid: @uid,
+          info: {
+              name: name,
+              email: email,
+              first_name: first_name,
+              last_name: last_name,
+              nickname: screen_name
+          },
+          extra: {
+            raw_info: {
+              attributes: {
+              }
+            }
+          }
+        )
+      }
+
+      it "should be populated from the fullName by default" do
+        result = @authenticator.after_authenticate(hash)
+        expect(result.name).to eq(name)
+      end
+
+      it "should fall back to firstname_lastname" do
+        hash.info.delete(:name)
+        result = @authenticator.after_authenticate(hash)
+        expect(result.name).to eq("#{first_name} #{last_name}")
+      end
+    end
+
     describe "sync_email" do
       let(:new_email) { "johndoe@demo.com" }
 


### PR DESCRIPTION
For `name`, the previous intention was to use the `fullName` attribute, and then fallback to "firstname lastname". However, a bug in the implementation meant that the `fullName` was skipped.

This commit updates the logic to lean on omniauth-saml's attribute_statements for the fullName, firstName and lastName attributes, and also updates the priority logic so that fullName is indeed prioritized.