### PR TITLE
DEV: Fallback to locale strings for name/title

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -3,3 +3,4 @@ en:
     login:
       saml:
         name: "SAML"
+        title: with SAML

--- a/plugin.rb
+++ b/plugin.rb
@@ -68,9 +68,11 @@ end
 require_relative "lib/discourse_saml/saml_omniauth_strategy"
 require_relative "lib/saml_authenticator"
 
-pretty_name = GlobalSetting.try(:saml_title) || "SAML"
-button_title = GlobalSetting.try(:saml_button_title) || GlobalSetting.try(:saml_title) || "with SAML"
+# Allow GlobalSettings to override the translations
+# If the global settings are not provided, will use the `js.login.saml.name` and `js.login.saml.title` translations
+name = GlobalSetting.try(:saml_title)
+button_title = GlobalSetting.try(:saml_button_title) || GlobalSetting.try(:saml_title)
 
 auth_provider title: button_title,
-              pretty_name: pretty_name,
+              pretty_name: name,
               authenticator: SamlAuthenticator.new('saml')


### PR DESCRIPTION
This means that the name/title can be set per-site and per-locale. This change is backwards-compatible - any existing sites which have configured the GlobalSettings will use those cluster-wide.