### PR TITLE
DEV: Use a helper method for all settings, and prefer SiteSettings

### DIFF
--- a/spec/integration/saml_forced_domains_spec.rb
+++ b/spec/integration/saml_forced_domains_spec.rb
@@ -19,7 +19,10 @@ describe "SAML Forced Domains" do
     ).tap { |u| u.activate }
   end
 
-  before { OmniAuth.config.test_mode = true }
+  before do
+    OmniAuth.config.test_mode = true
+    global_setting :saml_target_url, "https://example.com/samltarget"
+  end
 
   describe "username/password login" do
     it "works as normal when feature disabled" do


### PR DESCRIPTION
This centralises our logic for accessing settings. This particular commit should be a no-op. I intend to followup with the new site setting definitions in a future commit.