### PR TITLE
FIX: Remove prefix from base_url

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -369,7 +369,7 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
   end
 
   def self.saml_base_url
-    DiscourseSaml.setting(:saml_base_url) || Discourse.base_url
+    DiscourseSaml.setting(:base_url) || Discourse.base_url
   end
 
 end


### PR DESCRIPTION
The prefix is added by the helper. Adding it here causes it to be prefixed twice.