### PR TITLE
FEATURE: Allow the plugin to be configured using site settings

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,3 +4,8 @@ en:
       saml:
         name: "SAML"
         title: with SAML
+  admin_js:
+    admin:
+      site_settings:
+        categories: 
+          saml: SAML

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,3 +1,63 @@
 en:
   login:
     use_saml_auth: "Please use the company SSO to login with your account."
+  site_settings:
+    saml_enabled: Enable SAML authentication
+
+    saml_target_url: Target URL of the SAML Identity Provider (required)
+    saml_slo_target_url: Target URL for SAML Single Log Out
+
+    saml_name_identifier_format: If provided, will request a specific NameID (UID) format from the identity provider.
+
+    saml_cert: X.509 public certificate of the SAML identity provider (either this, or saml_cert_fingerprint, are required)
+    saml_cert_fingerprint: The X.509 public certificate fingerprint of the SAML identity provider (either this, or `saml_cert`, are required)
+    saml_cert_fingerprint_algorithm: Which algorithm should be used for SAML certificate fingerprinting?
+    saml_cert_multi: A secondary X.509 public certificate of the SAML identity provider. Useful during certificate rotations
+
+    saml_request_method: The HTTP method used when directing the user to the Identity Provider
+
+    saml_sp_certificate: SAML Service Provider X.509 certficate. Used to sign messages once enabled via the `saml_*_signed` settings"
+    saml_sp_private_key: SAML Service Provider X.509 private key. Used to sign messages once enabled via the `saml_*_signed` settings"
+    saml_authn_requests_signed: Enable Service Provider signatures for AuthNRequest
+    saml_want_assertions_signed: Enable Service Provider signatures for Assertions
+    saml_logout_requests_signed: Enable Service Provider signatures for SP-initiated logout
+    saml_logout_responses_signed: Enable Service Provider signatures for IDP-initiated logout responses
+
+    saml_request_attributes: A list of additional attributes which should be fetched from the service provider. `email`, `name`, `first_name`,  and `last_name` are always fetched.
+    saml_attribute_statements: Custom mappings of fields to their source SAML attributes. In the format `field:samlAttr1,samlAttr2`.
+    saml_use_attributes_uid: Use the 'uid' attribute as the unique user identifier instead of the default `name_id` field.
+
+    saml_skip_email_validation: Skip syntax validation of emails from the SAML IDP
+    saml_validate_email_fields: If any of these values are present in the `memberOf` attribute, then the email should be considered valid/verified
+    saml_default_emails_valid: "Consider SAML emails to be verified? Warning: this should only be `true` if you trust the IDP to verify email ownership"
+
+    saml_clear_username: Ignore the username from the SAML result
+    saml_omit_username: Prevent the user from changing the SAML username during signup
+    saml_auto_create_account: Skip the registration popup during signup with a SAML account
+
+    saml_sync_groups: Synchronize SAML groups with Discourse
+    saml_groups_fullsync: Should the assigned groups be completely synced including adding AND removing groups based on the IDP? Defaults to false. If set to true, `saml_sync_groups_list` and SAML attribute `groups_to_add`/`groups_to_remove` are not used.
+    saml_groups_attribute: The SAML attribute which contains group names
+    saml_groups_ldap_leafcn: If your IDP transmits `cn=groupname,cn=groups,dc=example,dc=com` you can set this to true to use only `groupname`. This is useful if you want to keep the standard group name length of Discourse (20 characters).
+    saml_sync_groups_list: If provided, these are the only Discourse groups which will have their membership controlled by SAML. If blank, all groups_to_add/groups_to_remove are used.
+
+    saml_user_field_statements: If provided, user fields will be set based on SAML attributes. Each entry should be in the format `saml_attribute_name:discourse_field_id`
+
+    saml_sync_email: Update the user email on every SAML login
+
+    saml_sync_moderator: Sync moderator status from SAML result?
+    saml_moderator_attribute: The SAML attribute which contains the moderator boolean
+    saml_sync_admin: Sync admin status from SAML result?
+    saml_admin_attribute: The SAML attribute which contains the admin boolean
+
+    saml_sync_trust_level: Set user trust level from SAML result
+    saml_trust_level_attribute: The SAML attribute which contains the trust level integer
+
+    saml_sync_locale: Set user locale from SAML result
+    saml_locale_attribute: The SAML attribute which contains the locale name
+
+    saml_forced_domains: Users with email addresses on these domains will be forced to use the SAML flow. They will be blocked from other login methods.
+
+    saml_log_auth: Store raw data about authentications in the `plugin_store_rows` database table.
+    saml_debug_auth: Enable debug logging to `/logs`
+    saml_base_url: Override the base URL for the Service Provider. Defaults to the forum base URL.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,0 +1,89 @@
+saml:
+  saml_enabled: false
+
+  saml_target_url: ""
+  saml_slo_target_url: ""
+
+  saml_name_identifier_format: ""
+
+  saml_cert:
+    default: ""
+    textarea: true
+  saml_cert_fingerprint: ""
+  saml_cert_fingerprint_algorithm:
+    type: enum
+    default: SHA1
+    choices:
+      - SHA1
+      - SHA256
+      - SHA384
+      - SHA512
+  saml_cert_multi:
+    default: ""
+    textarea: true
+
+  saml_request_method:
+    type: enum
+    default: GET
+    choices:
+      - GET
+      - POST
+  saml_sp_certificate:
+    default: ""
+    textarea: true
+  saml_sp_private_key:
+    default: ""
+    textarea: true
+  saml_authn_requests_signed: false
+  saml_want_assertions_signed: false
+  saml_logout_requests_signed: false
+  saml_logout_responses_signed: false
+
+  saml_request_attributes:
+    type: list
+    default: ""
+  saml_attribute_statements:
+    type: list
+    default: ""
+  saml_use_attributes_uid: false
+
+  saml_skip_email_validation: false
+  saml_validate_email_fields:
+    type: list
+    default: ""
+  saml_default_emails_valid: true
+
+  saml_clear_username: false
+  saml_omit_username: false
+  saml_auto_create_account: false
+
+  saml_sync_groups: false
+  saml_groups_fullsync: false
+  saml_groups_attribute: 'memberOf'
+  saml_groups_ldap_leafcn: false
+  saml_sync_groups_list:
+    type: list
+    default: ""
+
+  saml_user_field_statements:
+    type: list
+    default: ""
+
+  saml_sync_email: false
+  
+  saml_sync_moderator: false
+  saml_moderator_attribute: "isModerator"
+  saml_sync_admin: false
+  saml_admin_attribute: "isAdmin"
+  saml_sync_trust_level: false
+  saml_trust_level_attribute: "trustLevel"
+  saml_sync_locale: false
+  saml_locale_attribute: 'locale'
+
+  saml_forced_domains:
+    type: list
+    default: ""
+
+  saml_log_auth: false
+  saml_debug_auth: false
+  saml_base_url: ""

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -64,20 +64,20 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     strategy.options.deep_merge!(
       issuer: SamlAuthenticator.saml_base_url,
       idp_sso_target_url: setting(:target_url),
-      idp_slo_target_url: setting(:slo_target_url),
+      idp_slo_target_url: setting(:slo_target_url).presence,
       slo_default_relay_state: SamlAuthenticator.saml_base_url,
-      idp_cert_fingerprint: setting(:cert_fingerprint),
+      idp_cert_fingerprint: setting(:cert_fingerprint).presence,
       idp_cert_fingerprint_algorithm: setting(:cert_fingerprint_algorithm),
-      idp_cert: setting(:cert),
-      idp_cert_multi: setting(:cert_multi),
+      idp_cert: setting(:cert).presence,
+      idp_cert_multi: setting(:cert_multi).presence,
       request_attributes: request_attributes,
       attribute_statements: attribute_statements,
       assertion_consumer_service_url: SamlAuthenticator.saml_base_url + "/auth/#{name}/callback",
       single_logout_service_url: SamlAuthenticator.saml_base_url + "/auth/#{name}/slo",
-      name_identifier_format: setting(:name_identifier_format),
+      name_identifier_format: setting(:name_identifier_format).presence,
       request_method: (setting(:request_method)&.downcase == 'post') ? "POST" : "GET",
-      certificate: setting(:sp_certificate),
-      private_key: setting(:sp_private_key),
+      certificate: setting(:sp_certificate).presence,
+      private_key: setting(:sp_private_key).presence,
       security: {
         authn_requests_signed: !!setting(:authn_requests_signed),
         want_assertions_signed: !!setting(:want_assertions_signed),
@@ -126,7 +126,7 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     result.username = begin
       if attributes.present?
         username = attributes['screenName'].try(:first)
-        username = attributes['uid'].try(:first) if setting(:use_uid)
+        username = attributes['uid'].try(:first) if setting(:use_attributes_uid)
       end
 
       username ||= begin

--- a/plugin.rb
+++ b/plugin.rb
@@ -52,6 +52,15 @@ module ::DiscourseSaml
 end
 
 after_initialize do
+  if !!GlobalSetting.try("#{name}_target_url")
+    # Configured via environment variables. Hide all the site settings
+    # from the UI to avoid confusion
+    SiteSetting.defaults.all.keys.each do |k|
+      next if !k.to_s.start_with?("saml_")
+      SiteSetting.hidden_settings << k
+    end
+  end
+
   # "SAML Forced Domains" - Prevent login via email
   on(:before_email_login) do |user|
     if ::DiscourseSaml.is_saml_forced_domain?(user.email)

--- a/plugin.rb
+++ b/plugin.rb
@@ -14,25 +14,36 @@ gem 'rexml', '3.2.5'
 gem 'ruby-saml', '1.13.0'
 gem "omniauth-saml", '1.9.0'
 
+if !GlobalSetting.try("saml_target_url")
+  enabled_site_setting :saml_enabled
+end
+
 on(:before_session_destroy) do |data|
   next if !DiscourseSaml.setting(:slo_target_url).present?
   data[:redirect_url] = Discourse.base_path + "/auth/saml/spslo"
 end
 
 module ::DiscourseSaml
+  def self.enabled?
+    # Legacy - we only check the enabled site setting
+    # if the environment-variables are **not** present
+    !!GlobalSetting.try("saml_target_url") || SiteSetting.saml_enabled
+  end
+
   def self.setting(key, prefer_prefix: "saml_")
-    if prefer_prefix == "saml_" && SiteSetting.has_setting?("saml_#{key}")
+    if prefer_prefix == "saml_"
       SiteSetting.get("saml_#{key}")
     else
-      GlobalSetting.try("#{prefer_prefix}#{key}") || GlobalSetting.try("saml_#{key}")
+      GlobalSetting.try("#{prefer_prefix}#{key}") || SiteSetting.get("saml_#{key}")
     end
   end
 
   def self.is_saml_forced_domain?(email)
+    return if !enabled?
     return if !DiscourseSaml.setting(:forced_domains).present?
     return if email.blank?
 
-    DiscourseSaml.setting(:forced_domains).split(",").each do |domain|
+    DiscourseSaml.setting(:forced_domains).split(/[,|]/).each do |domain|
       return true if email.end_with?("@#{domain}")
     end
 

--- a/spec/integration/saml_forced_domains_spec.rb
+++ b/spec/integration/saml_forced_domains_spec.rb
@@ -20,8 +20,9 @@ describe "SAML Forced Domains" do
   end
 
   before do
+    SiteSetting.saml_enabled = true
     OmniAuth.config.test_mode = true
-    global_setting :saml_target_url, "https://example.com/samltarget"
+    SiteSetting.saml_target_url = "https://example.com/samltarget"
   end
 
   describe "username/password login" do
@@ -34,7 +35,7 @@ describe "SAML Forced Domains" do
     end
 
     it "blocks logins for blocked domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       post "/session.json", params: {
         login: saml_user.username, password: password
       }
@@ -62,14 +63,14 @@ describe "SAML Forced Domains" do
     end
 
     it "blocks login for blocked domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       post "/u/email-login.json", params: { login: saml_user.email }
       expect(response.status).to eq(403)
       expect_not_enqueued_with(job: :critical_user_email)
     end
 
     it "allows login for other domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       post "/u/email-login.json", params: { login: other_user.email }
       expect(response.status).to eq(200)
       expect_job_enqueued(job: :critical_user_email, args: {
@@ -103,7 +104,7 @@ describe "SAML Forced Domains" do
     end
 
     it "blocks login for blocked domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       get "/auth/google_oauth2/callback"
       expect(response.status).to eq(200)
       expect(response.body).to include(I18n.t("login.use_saml_auth"))
@@ -111,14 +112,14 @@ describe "SAML Forced Domains" do
     end
 
     it "allows SAML login for blocked domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       get "/auth/saml/callback"
       expect(response.status).to eq(302)
       expect(session[:current_user_id]).to eq(saml_user.id)
     end
 
     it "allows login for other domains" do
-      global_setting :saml_forced_domains, "samlonly.example.com"
+      SiteSetting.saml_forced_domains = "samlonly.example.com"
       mock_auth.info.email = other_user.email
       get "/auth/google_oauth2/callback"
       expect(response.status).to eq(302)

--- a/spec/integration/saml_post_mode_spec.rb
+++ b/spec/integration/saml_post_mode_spec.rb
@@ -4,19 +4,20 @@ require 'rails_helper'
 
 describe "SAML POST-mode functionality", type: :request do
   before do
+    SiteSetting.saml_enabled = true
     OmniAuth.config.test_mode = false
-    global_setting :saml_target_url, "https://example.com/samlidp"
+    SiteSetting.saml_target_url = "https://example.com/samlidp"
   end
 
   it "does not affect functionality when disabled" do
-    global_setting :saml_request_method, "GET"
+    SiteSetting.saml_request_method = "GET"
     post "/auth/saml"
     expect(response.status).to eq(302)
     expect(response.location).to start_with("https://example.com/samlidp")
   end
 
   it "serves an auto-submitting POST form when enabled" do
-    global_setting :saml_request_method, "POST"
+    SiteSetting.saml_request_method = "POST"
     post "/auth/saml"
     expect(response.status).to eq(200)
     expect(response.body).to have_tag(

--- a/spec/integration/saml_single_log_out_spec.rb
+++ b/spec/integration/saml_single_log_out_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe "SAML Single Log Out" do
   let(:user) { Fabricate(:user) }
+  before { SiteSetting.saml_enabled = true }
 
   it "does nothing when SLO is not configured" do
     sign_in(user)
@@ -13,7 +14,7 @@ describe "SAML Single Log Out" do
   end
 
   it "redirects to the omniauth route when SLO is configured" do
-    global_setting :saml_slo_target_url, "https://example.com/slo-target"
+    SiteSetting.saml_slo_target_url = "https://example.com/slo-target"
 
     sign_in(user)
     delete "/session/#{user.username}", xhr: true


### PR DESCRIPTION
GlobalSettings configured via environment variables will continue to take precendence, so this change is backwards compatible.

- `.presence` is added to string values, since 'unset' site settings are never `nil`
- saml_force_domains is split on `|` and `,` because site settings expect a `|`, while the old global setting expected a `,`