### PR TITLE
FIX: Ensure SAML follows after-login redirects

### DIFF
--- a/spec/integration/saml_cross_site_spec.rb
+++ b/spec/integration/saml_cross_site_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe "SAML cross-site with same-site cookie", type: :request do
+  before do
+    OmniAuth.config.test_mode = false
+    global_setting :saml_target_url, "https://example.com/samlidp"
+  end
+
+  it "serves an auto-submitting POST form" do
+    post "/auth/saml/callback", params: { "SAMLResponse" => "somesamldata" }
+    expect(response.status).to eq(200)
+    expect(response.body).to have_tag(
+      "form",
+      with: {
+        "action" => "http://test.localhost/auth/saml/callback",
+        "method" => "post",
+      }
+    )
+
+    expect(response.body).to have_tag(
+      "form input",
+      with: {
+        "name" => "SAMLResponse",
+        "value" => "somesamldata",
+        "type" => "hidden",
+      }
+    )
+
+    expect(response.body).to have_tag(
+      "form input",
+      with: {
+        "name" => "SameSite",
+        "value" => "1",
+        "type" => "hidden",
+      }
+    )
+
+    expect(response.body).to have_tag("script")
+  end
+
+  it "continues once the samesite form has been submitted" do
+    post "/auth/saml/callback", params: { "SAMLResponse" => "somesamldata", "SameSite" => "1" }
+    expect(response.status).to eq(302)
+    expect(response.location).to eq("/auth/failure?message=invalid_ticket&strategy=saml")
+  end
+end


### PR DESCRIPTION
SAML flows end in a cross-site POST back to Discourse. We have the SameSite=lax attributes on our session cookies so this cross-site POST request has no cookies, and therefore we are unable to check any values in the `session`.

This commit makes the browser re-submit the POST request in a SameSite context (i.e. with cookies). Upon receiving a cross-site POST, it renders a simple HTML form with some auto-submit JS. This form submits exactly the same data to the same URL, but this time the request will include the cookies, and authentication can complete properly