### PR TITLE
FIX: Do not override existing session cookie during callback

### DIFF
--- a/lib/discourse_saml/saml_omniauth_strategy.rb
+++ b/lib/discourse_saml/saml_omniauth_strategy.rb
@@ -21,6 +21,8 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
 
   def callback_phase
     if request.request_method.downcase.to_sym == :post && !request.params["SameSite"] && request.params["SAMLResponse"]
+      env[Rack::RACK_SESSION_OPTIONS][:skip] = true # Do not set any session cookies. They'll override our SameSite ones
+
       # Make browser re-issue the request in a same-site context so we get cookies
       # For this particular action, we explicitely **want** cross-site requests to include session cookies
       render_auto_submitted_form(

--- a/spec/integration/saml_cross_site_spec.rb
+++ b/spec/integration/saml_cross_site_spec.rb
@@ -38,6 +38,8 @@ describe "SAML cross-site with same-site cookie", type: :request do
     )
 
     expect(response.body).to have_tag("script")
+
+    expect(response.has_header?("Set-Cookie")).to eq(false)
   end
 
   it "continues once the samesite form has been submitted" do


### PR DESCRIPTION
Follow-up to d137e9814140f2bfa1ef1021bd0fb8b891378570. If the cross-site POST returns a Set-Cookie header, it will overwrite the existing session, and we'll lose the redirect URL. This commit instructs rack not to persist a session cookie in this response.