### PR TITLE
FIX: Ignore empty `saml_base_url` site setting

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -369,7 +369,7 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
   end
 
   def self.saml_base_url
-    DiscourseSaml.setting(:base_url) || Discourse.base_url
+    DiscourseSaml.setting(:base_url).presence || Discourse.base_url
   end
 
 end

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -494,4 +494,15 @@ describe SamlAuthenticator do
       end
     end
   end
+
+  describe ".base_url" do
+    it "works" do
+      expect(SamlAuthenticator.saml_base_url).to eq("http://test.localhost")
+    end
+
+    it "can be overriden by a setting" do
+      SiteSetting.saml_base_url = "https://override.example.com"
+      expect(SamlAuthenticator.saml_base_url).to eq("https://override.example.com")
+    end
+  end
 end


### PR DESCRIPTION
Regression introduced in e9f9150b