### PR TITLE
FIX: Correct after_create_account errors from 4e0a5e0a

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -196,13 +196,13 @@ class SamlAuthenticator < ::Auth::OAuth2Authenticator
     return if User.find_by_email(try_email).present?
 
     # Use a mutex here to counter SAML responses that are sent at the same time and the same email payload
-    DistributedMutex.synchronize("discourse_saml_#{email}") do
+    DistributedMutex.synchronize("discourse_saml_#{try_email}") do
       try_name = result.name.presence
       try_username = result.username.presence
 
       user_params = {
-        primary_email: UserEmail.new(email: email, primary: true),
-        name: try_name || User.suggest_name(try_username || email),
+        primary_email: UserEmail.new(email: try_email, primary: true),
+        name: try_name || User.suggest_name(try_username || try_email),
         username: UserNameSuggester.suggest(try_username || try_name || try_email || uid),
         active: true
       }

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -180,7 +180,8 @@ describe SamlAuthenticator do
           uid: @uid,
           info: {
               name: name,
-              email: email
+              email: email,
+              nickname: screen_name,
           },
           extra: {
             raw_info: {
@@ -200,24 +201,9 @@ describe SamlAuthenticator do
         expect(result.username).to eq(@uid.to_s)
       end
 
-      it 'should be equal to screenName' do
+      it 'should be equal to nickname, which omniauth-saml calculated from screenName' do
         result = @authenticator.after_authenticate(hash)
         expect(result.username).to eq(screen_name)
-      end
-
-      it 'should be populated from name' do
-        hash.extra = nil
-
-        result = @authenticator.after_authenticate(hash)
-        expect(result.username).to eq(name.sub(" ", "_"))
-      end
-
-      it 'should be populated from email' do
-        hash.extra = nil
-        hash.info.name = nil
-
-        result = @authenticator.after_authenticate(hash)
-        expect(result.username).to eq(email.split("@")[0])
       end
     end
 


### PR DESCRIPTION
Some variable renames were missed, and some specs are no longer relevant