### PR TITLE
FIX: Add `content-type` header to auto-submitting form

### DIFF
--- a/lib/discourse_saml/saml_omniauth_strategy.rb
+++ b/lib/discourse_saml/saml_omniauth_strategy.rb
@@ -73,8 +73,7 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
       </html>
     HTML
 
-    r = Rack::Response.new
-    r.write(html)
+    r = Rack::Response.new(html, 200, { 'content-type' => 'text/html' })
     r.finish
   end
 end

--- a/spec/integration/saml_post_mode_spec.rb
+++ b/spec/integration/saml_post_mode_spec.rb
@@ -20,6 +20,7 @@ describe "SAML POST-mode functionality", type: :request do
     SiteSetting.saml_request_method = "POST"
     post "/auth/saml"
     expect(response.status).to eq(200)
+    expect(response.headers["content-type"]).to eq("text/html")
     expect(response.body).to have_tag(
       "form",
       with: {


### PR DESCRIPTION
In the vast majority of cases, this wasn't causing a problem because browsers will auto-detect the content-type. However, if any intermediate proxies add the `X-Content-Type-Options: nosniff` header, then the html will be displayed as plain text, and login will be broken.