### PR TITLE
FIX: Ensure JS script path is correct for subfolder

### DIFF
--- a/lib/discourse_saml/saml_omniauth_strategy.rb
+++ b/lib/discourse_saml/saml_omniauth_strategy.rb
@@ -41,7 +41,7 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
   private
 
   def render_auto_submitted_form(destination:, params:)
-    submit_script_url = UrlHelper.absolute('/plugins/discourse-saml/javascripts/submit-form-on-load.js', GlobalSetting.cdn_url)
+    submit_script_url = UrlHelper.absolute("#{Discourse.base_path}/plugins/discourse-saml/javascripts/submit-form-on-load.js", GlobalSetting.cdn_url)
 
     inputs = params.map do |key, value|
       <<~HTML


### PR DESCRIPTION
The change in 245b70d4 means that the CSP middleware now activates for the `/auth/saml` route. That's good, but it also broke things for subfolder installations because the CSP includes the base_path, while the SAML JS script url did not. This commit fixes that, and adds an integration spec to ensure the script is included in the script_src directive for regular and subfolder sites.