### PR TITLE
DEV: Migrate plugin to ManagedAuthenticator and UserAssociatedAccount

### DIFF
--- a/db/migrate/20211230141200_migrate_saml_user_info.rb
+++ b/db/migrate/20211230141200_migrate_saml_user_info.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class MigrateSamlUserInfo < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+    INSERT INTO user_associated_accounts (
+      provider_name,
+      provider_uid,
+      user_id,
+      info,
+      last_used,
+      created_at,
+      updated_at
+    ) SELECT
+      'saml',
+      uid,
+      user_id,
+      json_build_object('email', email, 'name', name),
+      updated_at,
+      created_at,
+      updated_at
+    FROM oauth2_user_infos
+    WHERE provider = 'saml'
+    ON CONFLICT DO NOTHING
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,11 +2,9 @@
 
 # name: discourse-saml
 # about: SAML Auth Provider
-# version: 0.1
-# author: Robin Ward
+# version: 1.0
+# author: Discourse Team
 # url: https://github.com/discourse/discourse-saml
-
-require_dependency 'auth/oauth2_authenticator'
 
 gem 'macaddr', '1.0.0'
 gem 'uuid', '2.3.7'
@@ -103,4 +101,4 @@ button_title = GlobalSetting.try(:saml_button_title) || GlobalSetting.try(:saml_
 
 auth_provider title: button_title,
               pretty_name: name,
-              authenticator: SamlAuthenticator.new('saml')
+              authenticator: SamlAuthenticator.new

--- a/spec/integration/saml_staged_user_handling_spec.rb
+++ b/spec/integration/saml_staged_user_handling_spec.rb
@@ -38,7 +38,7 @@ describe "SAML staged user handling", type: :request do
     }
     expect(response.status).to eq(200)
 
-    expect(Oauth2UserInfo.where(user: staged).count).to eq(1)
+    expect(UserAssociatedAccount.where(user: staged).count).to eq(1)
     expect(staged.reload.staged).to eq(false)
 
     expect(session[:current_user_id]).to eq(staged.id)

--- a/spec/integration/saml_sync_attributes_spec.rb
+++ b/spec/integration/saml_sync_attributes_spec.rb
@@ -8,7 +8,7 @@ describe "SAML Overrides Email", type: :request do
   fab!(:new_email) { "new@example.com" }
   fab!(:new_username) { "newusername" }
   fab!(:user) { Fabricate(:user, email: initial_email, username: initial_username) }
-  fab!(:uac) { Oauth2UserInfo.create!(user: user, provider: "saml", uid: "12345") }
+  fab!(:uac) { UserAssociatedAccount.create!(user: user, provider_name: "saml", provider_uid: "12345") }
 
   before do
     SiteSetting.saml_enabled = true


### PR DESCRIPTION
All data will be automatically migrated from `oauth2_user_infos` to the `user_associated_accounts` table