### PR TITLE
FIX: Simplify data to store in `extra` column

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -89,8 +89,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
   end
 
   def primary_email_verified?(auth_token)
-
-    attributes = auth_token.extra&.[](:raw_info) || OneLogin::RubySaml::Attributes.new
+    attributes = OneLogin::RubySaml::Attributes.new(auth_token.extra&.[](:raw_info) || {})
 
     group_attribute = setting(:groups_attribute)
     if setting(:validate_email_fields).present? && attributes.multi(group_attribute).present?
@@ -121,6 +120,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
       auth.info[:nickname] = uid.to_s
     end
 
+    auth.extra = { "raw_info" => attributes.attributes }
     result = super
 
     if setting(:log_auth)

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -114,7 +114,7 @@ describe SamlAuthenticator do
 
       result = @authenticator.after_authenticate(hash)
       SiteSetting.saml_request_attributes.split("|").each do |name|
-        expect(result.user.custom_fields["saml_#{name}"]).to eq(hash.extra.raw_info.multi(name).join(","))
+        expect(result.user.custom_fields["saml_#{name}"]).to eq(hash.extra.raw_info[name].join(","))
       end
     end
 
@@ -131,7 +131,7 @@ describe SamlAuthenticator do
 
       SiteSetting.saml_user_field_statements.split("|").each do |statement|
         key, id = statement.split(":")
-        expect(result.user.custom_fields["user_field_#{id}"]).to eq(attrs.multi(key).join(","))
+        expect(result.user.custom_fields["user_field_#{id}"]).to eq(attrs[key].join(","))
       end
     end
 


### PR DESCRIPTION
In production, the SAML omniauth strategy returns some very complex data structures in the `extra` data. These have circular references, and can cause a "stack level too deep" error when serializing to JSON for the UserAssociatedAccount model. This commit simplifies thing so we only try to store the attributes hash.