### PR TITLE
DEV: include original certificate in `idp_cert_multi` variable.

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -360,8 +360,11 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
   def idp_cert_multi
     return unless setting(:cert_multi).present?
 
+    certificates = setting(:cert_multi).split('|')
+    certificates.push(setting(:cert)) if setting(:cert).present?
+
     {
-      signing: [setting(:cert_multi)],
+      signing: certificates,
       encryption: []
     }
   end


### PR DESCRIPTION
And add a option to include multiple certificates in site setting with "|" separator.