### PR TITLE
DEV: Add support for core content_security_policy_strict_dynamic

### DIFF
--- a/lib/discourse_saml/saml_omniauth_strategy.rb
+++ b/lib/discourse_saml/saml_omniauth_strategy.rb
@@ -39,6 +39,8 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
   private
 
   def render_auto_submitted_form(destination:, params:)
+    response_headers = { "content-type" => "text/html" }
+
     submit_script_url =
       UrlHelper.absolute(
         "#{Discourse.base_path}/plugins/discourse-saml/javascripts/submit-form-on-load.js",
@@ -68,12 +70,12 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
               </div>
             </noscript>
           </form>
-          <script src="#{CGI.escapeHTML(submit_script_url)}"></script>
+          <script src="#{CGI.escapeHTML(submit_script_url)}" nonce="#{ContentSecurityPolicy.try(:nonce_placeholder, response_headers)}"></script>
         </body>
       </html>
     HTML
 
-    r = Rack::Response.new(html, 200, { "content-type" => "text/html" })
+    r = Rack::Response.new(html, 200, response_headers)
     r.finish
   end
 end

--- a/spec/integration/saml_post_mode_spec.rb
+++ b/spec/integration/saml_post_mode_spec.rb
@@ -39,11 +39,17 @@ describe "SAML POST-mode functionality", type: :request do
 
     html = Nokogiri.HTML5(response.body)
     script_url = html.at("script").attribute("src").value
+    script_nonce = html.at("script").attribute("nonce").value
 
     csp = response.headers["content-security-policy"]
+
     script_src =
       csp.split(";").find { |directive| directive.strip.start_with?("script-src") }.split(" ")
-    included_in_csp = script_src.any? { |allowed_src| script_url.start_with?(allowed_src) }
+
+    included_in_csp =
+      script_src.any? do |allowed_src|
+        script_url.start_with?(allowed_src) || ("'nonce-#{script_nonce}'" == allowed_src)
+      end
 
     expect(included_in_csp).to eq(true)
   end
@@ -72,11 +78,15 @@ describe "SAML POST-mode functionality", type: :request do
 
     html = Nokogiri.HTML5(response.body)
     script_url = html.at("script").attribute("src").value
+    script_nonce = html.at("script").attribute("nonce").value
 
     csp = response.headers["content-security-policy"]
     script_src =
       csp.split(";").find { |directive| directive.strip.start_with?("script-src") }.split(" ")
-    included_in_csp = script_src.any? { |allowed_src| script_url.start_with?(allowed_src) }
+    included_in_csp =
+      script_src.any? do |allowed_src|
+        script_url.start_with?(allowed_src) || ("'nonce-#{script_nonce}'" == allowed_src)
+      end
 
     expect(included_in_csp).to eq(true)
   end


### PR DESCRIPTION
Uses https://github.com/discourse/discourse/pull/26052, but falls back to the old behavior if that method is not present