### PR TITLE
FEATURE: add to staff group when user become admin via sync

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -145,6 +145,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
       sync_admin(user, attributes)
       sync_trust_level(user, attributes)
       sync_locale(user, attributes)
+      Group.refresh_automatic_groups!(:admins, :moderators, :staff)
     end
 
     result.overrides_username = setting(:omit_username)
@@ -175,6 +176,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     sync_trust_level(user, attributes)
     sync_custom_fields(user, attributes, info)
     sync_locale(user, attributes)
+    Group.refresh_automatic_groups!(:admins, :moderators, :staff)
   end
 
   def auto_create_account(result, uid)

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -498,7 +498,10 @@ describe SamlAuthenticator do
       it "user should be a moderator (default param)" do
         hash = auth_hash("isModerator" => [1])
         result = @authenticator.after_authenticate(hash)
-        expect(result.user.moderator).to eq(true)
+        user = result.user
+
+        expect(user.moderator).to eq(true)
+        expect(user.groups.pluck(:name)).to include("moderators", "staff")
       end
 
       it "user should be a moderator (using specified saml_moderator_attribute)" do
@@ -515,7 +518,10 @@ describe SamlAuthenticator do
       it "user should be an admin (default param)" do
         hash = auth_hash("isAdmin" => [1])
         result = @authenticator.after_authenticate(hash)
-        expect(result.user.admin).to eq(true)
+        user = result.user
+
+        expect(user.admin).to eq(true)
+        expect(user.groups.pluck(:name)).to include("admins", "staff")
       end
 
       it "user should be an admin (using specified saml_admin_attribute)" do


### PR DESCRIPTION
Previously, since we didn't call 'refresh_automatic_groups' after when a user become admin/mod they didn't added to the group automatically.