### PR TITLE
FEATURE: add an option to include signed metadata element

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Add the following settings to your `discourse.conf` file:
 - `DISCOURSE_SAML_WANT_ASSERTIONS_SIGNED`: defaults to false
 - `DISCOURSE_SAML_LOGOUT_REQUESTS_SIGNED`: defaults to false
 - `DISCOURSE_SAML_LOGOUT_RESPONSES_SIGNED`: defaults to false
+- `DISCOURSE_SAML_METADATA_SIGNED`: defaults to false
 - `DISCOURSE_SAML_NAME_IDENTIFIER_FORMAT`: defaults to "urn:oasis:names:tc:SAML:2.0:protocol"
 - `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`: defaults to true
 - `DISCOURSE_SAML_VALIDATE_EMAIL_FIELDS`: defaults to blank. This setting accepts pipe separated group names that are supplied in `memberOf` attribute in SAML payload. If the group name specified in the value matches that from `memberOf` attribute than the `email_valid` is set to `true`, otherwise it defaults to `false`. This setting overrides `DISCOURSE_SAML_DEFAULT_EMAILS_VALID`.

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,6 +22,7 @@ en:
     saml_want_assertions_signed: Enable Service Provider signatures for Assertions
     saml_logout_requests_signed: Enable Service Provider signatures for SP-initiated logout
     saml_logout_responses_signed: Enable Service Provider signatures for IDP-initiated logout responses
+    saml_metadata_signed: Include a signature element within Service Provider metadata XML
 
     saml_request_attributes: A list of additional attributes which should be fetched from the service provider. `email`, `name`, `first_name`,  and `last_name` are always fetched.
     saml_attribute_statements: Custom mappings of fields to their source SAML attributes. In the format `field:samlAttr1,samlAttr2`.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -38,6 +38,7 @@ saml:
   saml_want_assertions_signed: false
   saml_logout_requests_signed: false
   saml_logout_responses_signed: false
+  saml_metadata_signed: false
 
   saml_request_attributes:
     type: list

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -78,6 +78,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
         want_assertions_signed: !!setting(:want_assertions_signed),
         logout_requests_signed: !!setting(:logout_requests_signed),
         logout_responses_signed: !!setting(:logout_responses_signed),
+        metadata_signed: !!setting(:metadata_signed),
         signature_method: XMLSecurity::Document::RSA_SHA1,
       },
       idp_slo_session_destroy:


### PR DESCRIPTION
Add a <ds:Signature> element to SP metadata XML.

Docs here:
https://github.com/SAML-Toolkits/ruby-saml?tab=readme-ov-file#signing-sp-metadata