### PR TITLE
FIX: replace idp_sxo_target_url with idp_sxo_service_url

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -58,8 +58,8 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
   def setup_strategy(strategy)
     strategy.options.deep_merge!(
       issuer: SamlAuthenticator.saml_base_url,
-      idp_sso_target_url: setting(:target_url),
-      idp_slo_target_url: setting(:slo_target_url).presence,
+      idp_sso_service_url: setting(:target_url),
+      idp_slo_service_url: setting(:slo_target_url).presence,
       slo_default_relay_state: SamlAuthenticator.saml_base_url,
       idp_cert_fingerprint: setting(:cert_fingerprint).presence,
       idp_cert_fingerprint_algorithm: setting(:cert_fingerprint_algorithm),


### PR DESCRIPTION
rename idp_sxo_target_url vars to idp_sxo_service_url according to upstream ruby-saml

this prevented SLO from working*. SSO works because of #44 which is probably why it wasn't caught yet

*threw HTTP 501 - Not Implemented