### PR TITLE
FEATURE: Allow multiple attributes for group sync and also using group full_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,11 @@ Add the following settings to your `discourse.conf` file:
 ### Group sync
 
 - `DISCOURSE_SAML_SYNC_GROUPS`: Sync groups. Defaults to false.
-- `DISCOURSE_SAML_GROUPS_ATTRIBUTE`: SAML attribute to use for group sync. Defaults to `memberOf`
+- `DISCOURSE_SAML_GROUPS_ATTRIBUTE`: SAML attribute to use for group sync. Defaults to `memberOf`, and accepts comma separated attributes `Country,Department`.
 - `DISCOURSE_SAML_GROUPS_FULLSYNC`: Should the assigned groups be completely synced including adding AND removing groups based on the IDP? Defaults to false. If set to true, `DISCOURSE_SAML_SYNC_GROUPS_LIST` and SAML attribute `groups_to_add`/`groups_to_remove` are not used.
 - `DISCOURSE_SAML_GROUPS_LDAP_LEAFCN`: If your IDP transmits `cn=groupname,cn=groups,dc=example,dc=com` you can set this to true to use only `groupname`. This is useful if you want to keep the standard group name length of Discourse (20 characters).
 - `DISCOURSE_SAML_SYNC_GROUPS_LIST`: Groups mentioned in this list are synced if they are referenced by the IDP (in `memberOf` SAML attribue). Any other groups will not be removed/updated.
+- `DISCOURSE_SAML_GROUPS_USE_FULL_NAME`: If set to true, will match groups based on Discourse Group `full_name` instead of the default `name`. This allows usage of group names with spaces in them, e.g. "North Africa" instead of "north_africa".
 
 ### Other Supported settings
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Add the following settings to your `discourse.conf` file:
 ### Group sync
 
 - `DISCOURSE_SAML_SYNC_GROUPS`: Sync groups. Defaults to false.
-- `DISCOURSE_SAML_GROUPS_ATTRIBUTE`: SAML attribute to use for group sync. Defaults to `memberOf`, and accepts comma separated attributes `Country,Department`.
+- `DISCOURSE_SAML_GROUPS_ATTRIBUTE`: SAML attribute to use for group sync. Defaults to `memberOf`, and accepts '|' separated attributes `Country|Department`.
 - `DISCOURSE_SAML_GROUPS_FULLSYNC`: Should the assigned groups be completely synced including adding AND removing groups based on the IDP? Defaults to false. If set to true, `DISCOURSE_SAML_SYNC_GROUPS_LIST` and SAML attribute `groups_to_add`/`groups_to_remove` are not used.
 - `DISCOURSE_SAML_GROUPS_LDAP_LEAFCN`: If your IDP transmits `cn=groupname,cn=groups,dc=example,dc=com` you can set this to true to use only `groupname`. This is useful if you want to keep the standard group name length of Discourse (20 characters).
 - `DISCOURSE_SAML_SYNC_GROUPS_LIST`: Groups mentioned in this list are synced if they are referenced by the IDP (in `memberOf` SAML attribue). Any other groups will not be removed/updated.

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,7 +59,9 @@ saml:
 
   saml_sync_groups: false
   saml_groups_fullsync: false
-  saml_groups_attribute: "memberOf"
+  saml_groups_attribute:
+    type: list
+    default: "memberOf"
   saml_groups_use_full_name: false
   saml_groups_ldap_leafcn: false
   saml_sync_groups_list:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -60,6 +60,7 @@ saml:
   saml_sync_groups: false
   saml_groups_fullsync: false
   saml_groups_attribute: "memberOf"
+  saml_groups_use_full_name: false
   saml_groups_ldap_leafcn: false
   saml_sync_groups_list:
     type: list

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -215,7 +215,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     raw_group_list =
       setting(:groups_attribute).split(",").flat_map { |attr| attributes.multi(attr.strip) || [] }
 
-    user_group_list = raw_group_list.map { |g| g.downcase.split(",") }.flatten
+    user_group_list = raw_group_list.compact.map { |g| g.downcase.split(",") }.flatten
 
     if setting(:groups_ldap_leafcn).present?
       # Change cn=groupname,cn=groups,dc=example,dc=com to groupname

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -211,7 +211,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     return if setting(:sync_groups).blank?
 
     groups_fullsync = setting(:groups_fullsync)
-    groups_attributes = setting(:groups_attribute).split(",")
+    groups_attributes = setting(:groups_attribute).split("|")
     group_match_column = setting(:groups_use_full_name) ? "full_name" : "name"
 
     groups_from_groups_attributes =

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -474,18 +474,18 @@ describe SamlAuthenticator do
 
         it "adds users to groups based on group's case insensitive full_names" do
           SiteSetting.saml_groups_attribute = "oneAttribute,twoAttribute" # ensure compat
-          SiteSetting.saml_sync_groups_list = [group1.full_name, group3.full_name].join("|") # ensure compat
+          SiteSetting.saml_sync_groups_list = [group1.full_name, group2.full_name].join("|") # ensure compat
 
           hash =
             auth_hash(
-              "oneAttribute" => [group1.full_name, group2.full_name],
-              "twoAttribute" => [group3.full_name.upcase],
+              "oneAttribute" => [group1.full_name, "I don't exist"],
+              "twoAttribute" => [group2.full_name],
             )
 
           result = authenticator.after_authenticate(hash)
           expect(result.user.groups.pluck(:name)).to contain_exactly(
             group1.name,
-            group3.name,
+            group2.name,
             original_group.name,
           )
         end

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -495,9 +495,6 @@ describe SamlAuthenticator do
           )
         end
 
-        it "functions correctly even with no prior user_associated_account" do
-        end
-
         it "allows the attribute to specify an array, and assigns groups from those attributes" do
           SiteSetting.saml_groups_attribute = "Country|Hemisphere"
           hash =
@@ -525,7 +522,7 @@ describe SamlAuthenticator do
 
           hash =
             auth_hash(
-              "oneAttribute" => [group1.full_name, "I don't exist"],
+              "oneAttribute" => [group1.full_name.upcase, "I don't exist"],
               "twoAttribute" => [group2.full_name],
             )
 

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -487,7 +487,7 @@ describe SamlAuthenticator do
         end
 
         it "allows the attribute to specify an array, and assigns groups from those attributes" do
-          SiteSetting.saml_groups_attribute = "Country,Hemisphere"
+          SiteSetting.saml_groups_attribute = "Country|Hemisphere"
           hash = auth_hash("Country" => [group1.name, group2.name], "Hemisphere" => [group3.name])
 
           result = authenticator.after_authenticate(hash)
@@ -504,7 +504,7 @@ describe SamlAuthenticator do
         before { SiteSetting.saml_groups_use_full_name = true }
 
         it "adds users to groups based on group's case insensitive full_names" do
-          SiteSetting.saml_groups_attribute = "oneAttribute,twoAttribute" # ensure compat
+          SiteSetting.saml_groups_attribute = "oneAttribute|twoAttribute" # ensure compat
           SiteSetting.saml_sync_groups_list = [group1.full_name, group2.full_name].join("|") # ensure compat
 
           hash =

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -330,7 +330,7 @@ describe SamlAuthenticator do
     describe "Group Syncing" do
       fab!(:group1) { Fabricate(:group, name: "uno", full_name: "Group One") }
       fab!(:group2) { Fabricate(:group, name: "dos", full_name: "Group Two") }
-      fab!(:group3) { Fabricate(:group, name: "tres") } # no full name on purpose
+      fab!(:group_without_fullname) { Fabricate(:group, name: "tres") }
       fab!(:original_group) do
         Fabricate(:group, name: "original_group", full_name: "The Origin").tap { |g| g.add(user) }
       end
@@ -342,7 +342,7 @@ describe SamlAuthenticator do
           hash =
             auth_hash(
               "memberOf" => [group1.name, group2.name],
-              "groups_to_add" => [group3.name],
+              "groups_to_add" => [group_without_fullname.name],
               "groups_to_remove" => [original_group.name],
             )
 
@@ -350,30 +350,37 @@ describe SamlAuthenticator do
           expect(result.user.groups.pluck(:name)).to contain_exactly(
             group1.name,
             group2.name,
-            group3.name,
+            group_without_fullname.name,
           )
         end
 
         it "sync users to the given groups within scope" do
-          SiteSetting.saml_sync_groups_list = [group2.name, group3.name, original_group.name].join(
-            "|",
-          )
+          SiteSetting.saml_sync_groups_list = [
+            group2.name,
+            group_without_fullname.name,
+            original_group.name,
+          ].join("|")
           hash =
             auth_hash(
               "memberOf" => [group1.name, group2.name],
-              "groups_to_add" => [group3.name],
+              "groups_to_add" => [group_without_fullname.name],
               "groups_to_remove" => [original_group.name],
             )
 
           result = authenticator.after_authenticate(hash)
-          expect(result.user.groups.pluck(:name)).to contain_exactly(group2.name, group3.name)
+          expect(result.user.groups.pluck(:name)).to contain_exactly(
+            group2.name,
+            group_without_fullname.name,
+          )
         end
       end
 
       describe "sync_groups with LDAP leaf cn" do
         let!(:group1_ldap) { "cn=#{group1.name},cn=groups,dc=example,dc=com" }
         let!(:group2_ldap) { "cn=#{group2.name},cn=groups,dc=example,dc=com" }
-        let!(:group3_ldap) { "cn=#{group3.name},cn=groups,dc=example,dc=com" }
+        let!(:group_without_fullname_ldap) do
+          "cn=#{group_without_fullname.name},cn=groups,dc=example,dc=com"
+        end
         let!(:original_group_ldap) { "cn=#{original_group.name},cn=groups,dc=example,dc=com" }
 
         before { SiteSetting.saml_groups_ldap_leafcn = true }
@@ -382,7 +389,7 @@ describe SamlAuthenticator do
           hash =
             auth_hash(
               "memberOf" => [group1_ldap, group2_ldap],
-              "groups_to_add" => [group3.name],
+              "groups_to_add" => [group_without_fullname.name],
               "groups_to_remove" => [original_group.name],
             )
 
@@ -392,24 +399,29 @@ describe SamlAuthenticator do
           expect(result.user.groups.pluck(:name)).to contain_exactly(
             group1.name,
             group2.name,
-            group3.name,
+            group_without_fullname.name,
           )
         end
 
         it "sync users to the groups within scope" do
-          SiteSetting.saml_sync_groups_list = [group2.name, group3.name, original_group.name].join(
-            "|",
-          )
+          SiteSetting.saml_sync_groups_list = [
+            group2.name,
+            group_without_fullname.name,
+            original_group.name,
+          ].join("|")
 
           hash =
             auth_hash(
               "memberOf" => [group1_ldap, group2_ldap],
-              "groups_to_add" => [group3.name],
+              "groups_to_add" => [group_without_fullname.name],
               "groups_to_remove" => [original_group.name],
             )
 
           result = authenticator.after_authenticate(hash)
-          expect(result.user.groups.pluck(:name)).to contain_exactly(group2.name, group3.name)
+          expect(result.user.groups.pluck(:name)).to contain_exactly(
+            group2.name,
+            group_without_fullname.name,
+          )
         end
       end
 
@@ -427,13 +439,13 @@ describe SamlAuthenticator do
         end
 
         it "full sync, ignoring values in group list and groups_to_add/groups_to_remove" do
-          SiteSetting.saml_sync_groups_list = [group2.name, group3.name].join("|")
+          SiteSetting.saml_sync_groups_list = [group2.name, group_without_fullname.name].join("|")
 
           hash =
             auth_hash(
               "memberOf" => [group1.name, group2.name],
               "groups_to_add" => [original_group.name],
-              "groups_to_remove" => [group3.name],
+              "groups_to_remove" => [group_without_fullname.name],
             )
 
           result = authenticator.after_authenticate(hash)
@@ -466,7 +478,7 @@ describe SamlAuthenticator do
             user:,
             extra: {
               raw_info: {
-                "memberOf" => [group3.name], # this is ignored as it is not the correct attribute
+                "memberOf" => [group_without_fullname.name], # this is ignored as it is not the correct attribute
                 "notTheDefault" => [group1.name], # this is the correct attribute
               },
             },
@@ -488,14 +500,18 @@ describe SamlAuthenticator do
 
         it "allows the attribute to specify an array, and assigns groups from those attributes" do
           SiteSetting.saml_groups_attribute = "Country|Hemisphere"
-          hash = auth_hash("Country" => [group1.name, group2.name], "Hemisphere" => [group3.name])
+          hash =
+            auth_hash(
+              "Country" => [group1.name, group2.name],
+              "Hemisphere" => [group_without_fullname.name],
+            )
 
           result = authenticator.after_authenticate(hash)
           expect(result.user.groups.pluck(:name)).to contain_exactly(
             original_group.name,
             group1.name,
             group2.name,
-            group3.name,
+            group_without_fullname.name,
           )
         end
       end


### PR DESCRIPTION
This PR 
- :one: extends the `saml_groups_attribute` to accept an array of attributes, and 
- :two: adds a new setting: `saml_groups_use_full_name`.
- :three: it ensures the group sync feature removes the groups from the old attributes if it exists

:one: 

Previously, we only allow usage of one attribute e.g. `SiteSetting.saml_groups_attribute="memberOf"`. This PR adds support for multiple attributes.

Assuming the following attributes in raw_info:

```
#<UserAssociatedAccount:
  provider_name: "saml",
  extra: {
    "raw_info"=> {
      "Name"=>["Tay, Steak"],
      "Email"=>["steak@tay.com"],
      "Country"=>["Singapore"],
      "Location"=>["Changi","Orchard"], 
      "memberOf"=>["Cats", "Animals"], 
    }
  }
```

With existing `SiteSetting.saml_groups_attribute="memberOf"` we would add Steak to 2 groups 
```
Group.where("LOWER(name) IN ?", ["cats", "animals"])
```

With the new feature we can set `SiteSetting.saml_groups_attribute="Country,Location"` and Steak would be added to 3 groups
```
Group.where("LOWER(name) IN ?", ["singapore", "changi", "orchard"])
```

:two: 

With `saml_groups_use_full_name`, the above query matches against `full_name` instead, allowing attributes to be spaced.

```
#<UserAssociatedAccount:
  provider_name: "saml",
  extra: {
    "raw_info"=> {
      "Location"=>["East Coast"], 
...
```

:three:

Previously, if group_sync is enabled, groups are only removed when there is full_sync (1-1 mapping of SAML group attribute to Discourse group). This means if full_sync is off, groups are only added to the user and never removed if the group attribute changes to a new value.

This PR fixes that bug as well.