### PR TITLE
Fix reconnect path so users can manually connect a SAML account

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -61,3 +61,6 @@ en:
     saml_log_auth: Store raw data about authentications in the `plugin_store_rows` database table.
     saml_debug_auth: Enable debug logging to `/logs`
     saml_base_url: Override the base URL for the Service Provider. Defaults to the forum base URL.
+
+    saml_can_connect_existing_user: Allow users to manually connect their SAML account
+    saml_can_revoke: Allow users to manually revoke their connected SAML account

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -93,3 +93,6 @@ saml:
   saml_replay_protection_enabled:
     default: false
     hidden: true
+
+  saml_can_connect_existing_user: false
+  saml_can_revoke: false

--- a/lib/discourse_saml/saml_omniauth_strategy.rb
+++ b/lib/discourse_saml/saml_omniauth_strategy.rb
@@ -36,6 +36,12 @@ class ::DiscourseSaml::SamlOmniauthStrategy < OmniAuth::Strategies::SAML
     end
   end
 
+  def extra
+    # extra[:response_object] contains a field `document` which breaks the to_json call in OmniAuthCallbacksController.persist_auth_token
+    # with a SystemStackError. We don't actually use extra[:response_object] anywhere so just exclude it
+    super.except(:response_object)
+  end
+
   protected
 
   def handle_response(raw_response, opts, settings)

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -369,11 +369,11 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
   end
 
   def can_connect_existing_user?
-    false
+    setting(:can_connect_existing_user)
   end
 
   def can_revoke?
-    false
+    setting(:can_revoke)
   end
 
   def self.saml_base_url

--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -106,11 +106,18 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     end
   end
 
-  def after_authenticate(auth)
+  def after_authenticate(auth, existing_account: nil)
     info = auth.info
 
     extra_data = auth.extra || {}
+
     attributes = extra_data[:raw_info] || OneLogin::RubySaml::Attributes.new
+
+    # During a reconnect, auth gets converted to json and back and auth.extra[:raw_info] ends up as a
+    # Hashie::Array instead of a OneLogin::RubySaml::Attributes.
+    if !attributes.is_a? OneLogin::RubySaml::Attributes
+      attributes = OneLogin::RubySaml::Attributes.new(attributes.to_h)
+    end
 
     auth[:uid] = attributes.single("uid") || auth[:uid] if setting(:use_attributes_uid)
     uid = auth[:uid]

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -669,6 +669,17 @@ describe SamlAuthenticator do
         expect(user.groups.find(group.id).present?).to eq(true)
       end
     end
+
+    it "handles extra[:raw_info] being a Hashie array" do
+      hash = auth_hash({ "Email" => "testemail@test.com", "Name" => "test name" })
+
+      # When the OneLogin::RubySaml::Attributes is serialized/deserialized, we get a Hashie::Array back
+      hash = OmniAuth::AuthHash.new(JSON.parse(hash.to_json))
+      expect(hash.extra[:raw_info]).to be_a(Hashie::Array)
+
+      result = authenticator.after_authenticate(hash)
+      expect(result).to be_a(Auth::Result)
+    end
   end
 
   describe ".base_url" do


### PR DESCRIPTION
This adds site settings to enable/disable users from manually connecting and revoking SAML associated accounts, and also fixes a couple issues I found while connecting a SAML account to an existing user.

First, [omniauth-saml](https://github.com/omniauth/omniauth-saml) adds a field `response_object` to the `extra` part of the auth hash, containing the entire `OneLogin::RubySaml::Response` object data. 

When reconnect=true, OmniauthCallbacksController serializes the auth hash into JSON to save it in the session, so it can be recreated after reconnecting the user. I was seeing a **SystemStackError** during the `to_json` call on the auth hash trying to serialize the field `extra[:response_object][:document]` (It's an XMLSecurity::SignedDocument that resolves to the string "<UNDEFINED> ... </>"...). To fix, I'm just dropping the whole `extra[:response_object]` since it doesn't appear to be used anywhere.

Second, the auth hash field `extra[:raw_info]` is a OneLogin::RubySaml::Attributes object, which ends up being recreated as a Hashie::Array instead during deserialization from json. The fix is to build a new OneLogin::RubySaml::Attributes from the Hashie::Array explicitly in this case.