### PR TITLE
DEV: Add setting for icon on SAML login button and associated accounts table

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -96,3 +96,5 @@ saml:
 
   saml_can_connect_existing_user: false
   saml_can_revoke: false
+
+  saml_icon: user

--- a/plugin.rb
+++ b/plugin.rb
@@ -112,4 +112,7 @@ require_relative "lib/saml_authenticator"
 name = GlobalSetting.try(:saml_title)
 button_title = GlobalSetting.try(:saml_button_title) || GlobalSetting.try(:saml_title)
 
-auth_provider title: button_title, pretty_name: name, authenticator: SamlAuthenticator.new
+auth_provider icon_setting: :saml_icon,
+              title: button_title,
+              pretty_name: name,
+              authenticator: SamlAuthenticator.new


### PR DESCRIPTION
Allows admins to set up an alternative to the "user" icon, displayed on the login/signup screen buttons and the associated accounts section in user preferences.