### PR TITLE
FIX: Support URL-based SAML attribute names from IdPs

### DIFF
--- a/lib/saml_authenticator.rb
+++ b/lib/saml_authenticator.rb
@@ -37,7 +37,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     setting(:attribute_statements)
       .split("|")
       .each do |statement|
-        attrs = statement.split(":")
+        attrs = statement.split(":", 2)
         next if attrs.size != 2 || attrs[0].blank? || attrs[1].blank?
         result[attrs[0].strip] |= attrs[1].split(",").compact_blank.map(&:strip)
       end
@@ -296,7 +296,7 @@ class SamlAuthenticator < ::Auth::ManagedAuthenticator
     statements
       .split("|")
       .each do |statement|
-        key, field_id = statement.split(":")
+        key, _, field_id = statement.rpartition(":")
         next if key.blank? || field_id.blank?
 
         val = info[key] || attributes.multi(key)&.join(",")

--- a/spec/saml_authenticator_spec.rb
+++ b/spec/saml_authenticator_spec.rb
@@ -119,6 +119,16 @@ describe SamlAuthenticator do
         end
     end
 
+    it "syncs user fields when the attribute name is a URL (e.g. Entra ID claims)" do
+      claim = "http://schemas.microsoft.com/identity/claims/displayname"
+      SiteSetting.saml_user_field_statements = "#{claim}:2"
+
+      hash = auth_hash(claim => ["Jane Doe"])
+
+      result = authenticator.after_authenticate(hash)
+      expect(result.user.custom_fields["user_field_2"]).to eq("Jane Doe")
+    end
+
     it "syncs user locale" do
       SiteSetting.saml_sync_locale = true
       user_locale = "fr"
@@ -644,6 +654,18 @@ describe SamlAuthenticator do
         SiteSetting.saml_attribute_statements =
           "company_name:company,business|phone:mobile,contact_no"
         expect(authenticator.attribute_statements.count).to eq(7)
+      end
+
+      it "parses URL-based attribute names (e.g. Entra ID claims)" do
+        SiteSetting.saml_attribute_statements =
+          "name:http://schemas.microsoft.com/identity/claims/displayname|first_name:http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname"
+
+        expect(authenticator.attribute_statements["name"]).to include(
+          "http://schemas.microsoft.com/identity/claims/displayname",
+        )
+        expect(authenticator.attribute_statements["first_name"]).to include(
+          "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname",
+        )
       end
     end
 


### PR DESCRIPTION
We use `:` as a special character for defining configuration mappings. This was clashing with the colons in URL-based attribute names. The solution is to only split on the first colon (when the saml attribute is on the right-hand-side), or the last colon (when the saml attribute is on the left-hand-side)